### PR TITLE
Adding support for latest applier

### DIFF
--- a/inventory/host_vars/projects-and-policies.yml
+++ b/inventory/host_vars/projects-and-policies.yml
@@ -5,7 +5,7 @@ openshift_cluster_content:
   content:
   - name: "{{ ci_cd_namespace }}"
     template: "{{ playbook_dir }}/templates/project-requests.yml"
-    template_action: create
+    action: create
     params: "{{ playbook_dir }}/params/project-requests-ci-cd"
     tags:
     - projects

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
   scm: git
-  version: v3.7.2
+  version: master
   name: openshift-applier


### PR DESCRIPTION
To support passing command line params, we need to use the latest `openshift-applier`